### PR TITLE
enable adding/editing global vars via kitchen.yml

### DIFF
--- a/lib/kitchen/driver/ScalrAPI.rb
+++ b/lib/kitchen/driver/ScalrAPI.rb
@@ -123,4 +123,10 @@ class ScalrAPI
 		return response['data']
 	end
 
+        #Edit items in API via PATCH
+        def edit(url, data)
+          response = self.request('PATCH', url, data)
+          return response['data']
+        end
+
 end


### PR DESCRIPTION
we need to add specific scalr global variables when spinning up new farms. this PR allows adding or editing inherited global vars via kitchen.yml. i had to add a new scalr_api.edit method to use 'PATCH' instead of 'POST'. i'm not happy with suppressing the output of the scalr_api.fetch method but i don't know of a better way to test for the existence of variables before attempting to create them.

example config
```
      scalr_global_variables:
        Existing_Var:
          value: New_Value
        New_Var:
          value: New_Value
          description: New_Description
          category: Uncategrozied
```