### PR TITLE
SCALRCORE-8165 APIv2 > Image mode in kitchen-scalr has be broken

### DIFF
--- a/lib/kitchen/driver/scalr.rb
+++ b/lib/kitchen/driver/scalr.rb
@@ -249,7 +249,6 @@ module Kitchen
           "category" => {
                           "id" => 1
                         },
-          "deprecated" => false,
           "description" => "test kitchen role",
           "name" => ruuid,
           "os" => {


### PR DESCRIPTION
After Scalr version  7.7.7 deprecated field is read-only